### PR TITLE
[Issue-149] Added checks to find the exported values of FQDN & HOSTIP before proceeding with deployment.

### DIFF
--- a/.github/workflows/build_deploy_test.yml
+++ b/.github/workflows/build_deploy_test.yml
@@ -15,7 +15,8 @@ name: build_deploy_test
 
 on:
   pull_request:
-    branches: [ development ]
+    branches:
+      - '**'
 
 jobs:
 

--- a/.github/workflows/build_unittest.yml
+++ b/.github/workflows/build_unittest.yml
@@ -15,7 +15,8 @@ name: build_unittest
 
 on:
   pull_request:
-    branches: [ development ]
+    branches:
+      - '**'
 
 jobs:
 

--- a/build/odimra/makedep.sh
+++ b/build/odimra/makedep.sh
@@ -16,6 +16,14 @@
 # Script is for generating certificate and private key
 # for Client mode connection usage only
 
+if [[ -z $FQDN ]]; then
+	echo "[ERROR] Set FQDN to environment of the host machine using the following command: export FQDN=<user_preferred_fqdn_for_host>"
+	exit 1
+fi
+if [[ -z $HOSTIP ]]; then
+	echo "[ERROR] Set the environment variable, HOSTIP to the IP address of your system using following coomand: export HOSTIP=<ip_address_of_your_system>"
+        exit 1
+fi
 RootServiceUUID=$(uuidgen)
 sed -i "s#\"RootServiceUUID\".*#\"RootServiceUUID\": \"${RootServiceUUID}\",#" build/odimra/odimra_config/odimra_config.json
 


### PR DESCRIPTION
After fixing the pre-check logic comes into play and validates the required/mandatory env variables before deployment else fails like below:
bruce@odim:~/ODIM$ make all
cp -a svc-account-session build/odimra/odimra/; cp -a svc-aggregation build/odimra/odimra/; cp -a svc-api build/odimra/odimra/; cp -a svc-events build/odimra/odimra/; cp -a svc-fabrics build/odimra/odimra/; cp -a svc-managers build/odimra/odimra/; cp -a svc-systems build/odimra/odimra/; cp -a svc-task build/odimra/odimra/; cp -a svc-update build/odimra/odimra/; cp -a lib-dmtf build/odimra/odimra/; cp -a lib-messagebus build/odimra/odimra/; cp -a lib-persistence-manager build/odimra/odimra/; cp -a lib-utilities build/odimra/odimra/; cp -a plugin-redfish build/odimra/odimra/;
cp -f lib-utilities/config/odimra_config.json build/odimra/odimra_config/odimra_config.json
cp -f plugin-redfish/config/config.json build/RFPlugin/plugin_config/config_redfish_plugin.json
cp -f lib-messagebus/platforms/platformconfig.toml build/odimra/odimra_config/
cp -f lib-messagebus/platforms/platformconfig.toml build/RFPlugin/plugin_config/platformconfig.toml
cp -f lib-utilities/config/schema.json build/odimra/odimra_config/
cp -f lib-utilities/etc/* build/odimra/odimra_config/registrystore
build/odimra/makedep.sh
**[ERROR] Set the environment variable, HOSTIP to the IP address of your system using following coomand: export HOSTIP=<ip_address_of_your_system>**
Makefile:31: recipe for target 'dep' failed
make: *** [dep] Error 1
